### PR TITLE
Update ruby-align.json STP supports ruby-align

### DIFF
--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
`ruby-align` supported by STP.

Commits:
https://github.com/WebKit/WebKit/commit/5aefb4085f13a387a6a4c11ef2d8f7b437889070 https://github.com/WebKit/WebKit/commit/9ef3ca69ef4a8389aea04a7af2180d414e828dba

Screenshot of implementation in STP:
<img width="1582" alt="ruby-align is supported by STP" src="https://github.com/francescorn/browser-compat-data/assets/113309999/cd6961dd-7f44-4806-924a-6a2bc3996d6e">