### PR TITLE
Update color.json-  STP 189 supports `light-dark`, updating to `"preview"`

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -785,8 +785,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/262914"
+                "version_added": "preview",
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

STP 189 supports `light-dark` mode.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I tested MDN's example and it works in STP 189.
<img width="1826" alt="mdn_playground_light-dark_stp_189" src="https://github.com/francescorn/browser-compat-data/assets/113309999/608b764d-932a-4f65-b3a2-fd365c4fc9da">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[STP 189 release notes](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-189)
[Webkit release notes](https://webkit.org/blog/15050/release-notes-for-safari-technology-preview-189/).

It is implemented by: https://github.com/WebKit/WebKit/commit/42f9569ae95a1bbef0a26f460bdaa7efdb637fff
`color-scheme` dependent was fixed in: https://github.com/WebKit/WebKit/pull/25394
#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
